### PR TITLE
Refactoring: Convert QuickTextSearchRequestor to interface

### DIFF
--- a/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
+++ b/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch;singleton:=true
-Bundle-Version: 1.1.300.qualifier
+Bundle-Version: 1.1.400.qualifier
 Bundle-Activator: org.eclipse.text.quicksearch.internal.ui.QuickSearchActivator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.113.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",

--- a/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/core/QuickTextSearchRequestor.java
+++ b/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/core/QuickTextSearchRequestor.java
@@ -13,7 +13,7 @@
 package org.eclipse.text.quicksearch.internal.core;
 
 /**
- * Plays a similar role than SearchReqeustor in eclipse Searches. I.e. a search requestor
+ * Plays a similar role than SearchReqeustor in Eclipse searches. I.e. a search requestor
  * is some entity accepting the results of a search. Typically the requestor displays the
  * result to the user.
  * <p>
@@ -24,30 +24,31 @@ package org.eclipse.text.quicksearch.internal.core;
  *
  * @author Kris De Volder
  */
-public class QuickTextSearchRequestor {
+@SuppressWarnings("unused")
+public interface QuickTextSearchRequestor {
 
 	/**
 	 * Called when a line of text containing the search text is found.
 	 */
-	public void add(LineItem match) {}
+	default void add(LineItem match) {}
 
 	/**
 	 * Called when a previously added line of text needs to be redisplayed (this happens if
 	 * the query has changed but still matches the line. I.e. the line is still a match, but
 	 * the highlighting of the search term is different.
 	 */
-	public void update(LineItem match) {}
+	default void update(LineItem match) {}
 
 	/**
 	 * Called when a line of text previously added is no longer a match for the current query.
 	 * I.e. the line should no longer be displayed.
 	 */
-	public void revoke(LineItem line) {}
+	default void revoke(LineItem line) {}
 
 	/**
 	 * Called when all previous results have become revoked at once.
 	 * This happens when a query is changed in such a way that it can't be updated
 	 * incrementally but needs to be completely restarted.
 	 */
-	public void clear() {}
+	default void clear() {}
 }

--- a/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchQuickAccessComputer.java
+++ b/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchQuickAccessComputer.java
@@ -31,7 +31,7 @@ import org.eclipse.ui.quickaccess.IQuickAccessComputerExtension;
 import org.eclipse.ui.quickaccess.QuickAccessElement;
 import org.eclipse.ui.texteditor.ITextEditor;
 
-public class QuickSearchQuickAccessComputer extends QuickTextSearchRequestor implements IQuickAccessComputer, IQuickAccessComputerExtension {
+public class QuickSearchQuickAccessComputer implements QuickTextSearchRequestor, IQuickAccessComputer, IQuickAccessComputerExtension {
 
 	private static final int MAX_ENTRIES = 20;
 	private static final long TIMEOUT = 200;


### PR DESCRIPTION
Change the type of QuickTextSearchRequestor from class to interface.
The nature of it is more define an interface. The intention of having
a class here might have been to have empty default methods that are
overridden by sub-types. The class was not ever instantiated directly.