### PR TITLE
NPE in ProjectionViewer.processDeletions() (Fixes #24)

### DIFF
--- a/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -1053,7 +1053,9 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 			ProjectionAnnotation annotation = (ProjectionAnnotation) removedAnnotation;
 			if (annotation.isCollapsed()) {
 				Position expanded= event.getPositionOfRemovedAnnotation(annotation);
-				expand(expanded.getOffset(), expanded.getLength(), fireRedraw);
+				if (expanded != null) {
+					expand(expanded.getOffset(), expanded.getLength(), fireRedraw);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
getPositionOfRemovedAnnotation() contract allows null return, so check
for null.

See https://github.com/eclipse-platform/eclipse.platform.text/issues/24