### PR TITLE
Improve FileSearch performance (fixes #29)

### DIFF
--- a/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchQuery.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchQuery.java
@@ -251,7 +251,9 @@ public class FileSearchQuery implements ISearchQuery {
 
 	@Override
 	public String getLabel() {
-		return SearchMessages.FileSearchQuery_label;
+		Pattern searchPattern = getSearchPattern();
+		return searchPattern.pattern().isEmpty() ? SearchMessages.FileSearchQuery_label
+				: Messages.format(SearchMessages.TextSearchVisitor_textsearch_task_label, searchPattern.pattern());
 	}
 
 	public String getSearchString() {


### PR DESCRIPTION
* Read each file only once (if it fits in the buffers) => ~ 30% faster

* Immediate report search result while still searching => faster visible

* Share workload between threads to avoid that single job with huge file
is running much longer then the others => faster finished.

* Set current filename as job name => better progress report.