### PR TITLE
Remove useless test requirement on org.eclipse.equinox.event

### DIFF
--- a/org.eclipse.jface.text.tests/pom.xml
+++ b/org.eclipse.jface.text.tests/pom.xml
@@ -22,7 +22,6 @@
   <version>3.12.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
-  	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.jface.text.tests.JFaceTextTestSuite</testClass>
   </properties>
   <build>
@@ -34,14 +33,6 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
-          <dependencies>
-            <dependency>
-              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/org.eclipse.search.tests/pom.xml
+++ b/org.eclipse.search.tests/pom.xml
@@ -21,7 +21,6 @@
   <version>3.10.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
-  	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.search.tests.AllSearchTests</testClass>
   </properties>
   <build>
@@ -33,14 +32,6 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
-          <dependencies>
-            <dependency>
-              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/org.eclipse.ui.editors.tests/pom.xml
+++ b/org.eclipse.ui.editors.tests/pom.xml
@@ -21,7 +21,6 @@
   <version>3.12.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
-  	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.ui.editors.tests.EditorsTestSuite</testClass>
   </properties>
   <build>
@@ -33,14 +32,6 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
-          <dependencies>
-            <dependency>
-              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/org.eclipse.ui.genericeditor.tests/pom.xml
+++ b/org.eclipse.ui.genericeditor.tests/pom.xml
@@ -21,7 +21,6 @@
   <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
-  	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.ui.genericeditor.tests.GenericEditorTestSuite</testClass>
   </properties>
   <build>
@@ -33,14 +32,6 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
-          <dependencies>
-            <dependency>
-              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/org.eclipse.ui.workbench.texteditor.tests/pom.xml
+++ b/org.eclipse.ui.workbench.texteditor.tests/pom.xml
@@ -21,7 +21,6 @@
   <version>3.13.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
-  	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.ui.workbench.texteditor.tests.WorkbenchTextEditorTestSuite</testClass>
   </properties>
   <build>
@@ -33,14 +32,6 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
-          <dependencies>
-            <dependency>
-              <!-- workaround for missing dependency in org.eclipse.e4.ui.services: https://bugs.eclipse.org/462862 -->
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Bug for which this was workaround is not needed for long time.

Change-Id: Idc77b384e172cc2bda93f8df3c523e16a0d3c9b5