### PR TITLE
Revert "AnnotationModel uses inefficient iteration over map (Reopens #21)"

### DIFF
--- a/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.12.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/org.eclipse.text/src/org/eclipse/jface/text/source/AnnotationModel.java
+++ b/org.eclipse.text/src/org/eclipse/jface/text/source/AnnotationModel.java
@@ -640,13 +640,13 @@ public class AnnotationModel implements IAnnotationModel, IAnnotationModelExtens
 			fDocumentChanged= false;
 
 			ArrayList<Annotation> deleted= new ArrayList<>();
+			Iterator<Annotation> e= getAnnotationMap().keySetIterator();
 			IAnnotationMap annotations= getAnnotationMap();
-			Iterator<Entry<Annotation, Position>> iterator = annotations.entrySet().iterator();
-			while (iterator.hasNext()) {
-				Entry<Annotation, Position> entry= iterator.next();
-				Position p= entry.getValue();
+			while (e.hasNext()) {
+				Annotation a= e.next();
+				Position p= annotations.get(a);
 				if (p == null || p.isDeleted())
-					deleted.add(entry.getKey());
+					deleted.add(a);
 			}
 
 			if (fireModelChanged && forkNotification) {
@@ -789,11 +789,10 @@ public class AnnotationModel implements IAnnotationModel, IAnnotationModelExtens
 	protected void removeAllAnnotations(boolean fireModelChanged) {
 		IAnnotationMap annotations= getAnnotationMap();
 		if (fDocument != null) {
-			Iterator<Entry<Annotation, Position>> e= getAnnotationMap().entrySet().iterator();
+			Iterator<Annotation> e= getAnnotationMap().keySetIterator();
 			while (e.hasNext()) {
-				Entry<Annotation, Position> entry= e.next();
-				Annotation a= entry.getKey();
-				Position p= entry.getValue();
+				Annotation a= e.next();
+				Position p= annotations.get(a);
 				removePosition(fDocument, p);
 //				p.delete();
 				synchronized (getLockObject()) {


### PR DESCRIPTION
This reverts commit db6a3b4064f214e154956130197bc73aff082708 because
this change may cause inconsistent model state in case of parallel
operations on the annotations map (key set iterator was working on a
snapshot, but entry set is not).

See discussion on
https://github.com/eclipse-platform/eclipse.platform.text/pull/22