### PR TITLE
Add LinkedModeUI.doExit using a DocumentEvent #33

### DIFF
--- a/org.eclipse.jface.text/.settings/.api_filters
+++ b/org.eclipse.jface.text/.settings/.api_filters
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jface.text" version="2">
-    <resource path="src/org/eclipse/jface/text/TextViewer.java" type="org.eclipse.jface.text.TextViewer">
-        <filter id="572522506">
+    <resource path="src/org/eclipse/jface/text/link/LinkedModeUI.java" type="org.eclipse.jface.text.link.LinkedModeUI$IExitPolicy">
+        <filter comment="A new default IExitPolicy.doExit(LinkedModeModel model, DocumentEvent event)  method is added. Despite the fact that the interface is implementable by Clients and https://wiki.eclipse.org/Evolving_Java-based_APIs_2#Evolving_API_Interfaces say that such a change may 'break compatibility',  we don't know any such client that may implement such a method at present, so we believe this change will NOT add any compatibility break." id="404000815">
             <message_arguments>
-                <message_argument value="ChildDocumentManager"/>
-                <message_argument value="TextViewer"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/jface/text/templates/persistence/TemplatePersistenceData.java" type="org.eclipse.jface.text.templates.persistence.TemplatePersistenceData">
-        <filter comment="Extended to prevent API breakage" id="571473929">
-            <message_arguments>
-                <message_argument value="TemplatePersistenceData"/>
-                <message_argument value="TemplatePersistenceData"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/jface/text/templates/persistence/TemplateReaderWriter.java" type="org.eclipse.jface.text.templates.persistence.TemplateReaderWriter">
-        <filter comment="Extended to prevent API breakage" id="571473929">
-            <message_arguments>
-                <message_argument value="TemplateReaderWriter"/>
-                <message_argument value="TemplateReaderWriter"/>
+                <message_argument value="org.eclipse.jface.text.link.LinkedModeUI.IExitPolicy"/>
+                <message_argument value="doExit(LinkedModeModel, DocumentEvent)"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/link/LinkedModeUI.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/link/LinkedModeUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -277,6 +277,19 @@ public class LinkedModeUI {
 		 *         should be taken
 		 */
 		ExitFlags doExit(LinkedModeModel model, VerifyEvent event, int offset, int length);
+
+		/**
+		 * Checks whether the linked mode should be left after receiving the given
+		 * <code>DocumentEvent</code>, especially allowing to control Copy-Paste operations.
+		 *
+		 * @param model the linked mode model
+		 * @param event the document event
+		 * @return valid exit flags or <code>null</code> if no special action should be taken
+		 * @since 3.21
+		 */
+		default ExitFlags doExit(LinkedModeModel model, DocumentEvent event) {
+			return null;
+		}
 	}
 
 	/**
@@ -393,6 +406,15 @@ public class LinkedModeUI {
 					}
 
 					leave(ILinkedModeListener.EXTERNAL_MODIFICATION);
+					return;
+				}
+			}
+
+			// Apply  ExitPolicy to any inserted text if the insertion is made inside a linked region
+			if (fExitPolicy != null) {
+				ExitFlags flags= fExitPolicy.doExit(fModel, event);
+				if (flags != null) {
+					leave(flags.flags);
 					return;
 				}
 			}


### PR DESCRIPTION
Copy-Paste doesn't trigger Linked Editing IExitPolicy.doExit(...) so, a new default 'doExit()'  method is added to
the IExitPolicy interface in order to control exiting the Linked Editing Mode on Paste operations.
The method takes a `DocumentEvent` as an argument and is to be used from `DocumentListener` to check
if we should exit the linked mode.

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>