### PR TITLE
Bug 541178 - Cancel during file search

### DIFF
--- a/org.eclipse.search/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -274,6 +274,10 @@ public class TextSearchVisitor {
 					fNumberOfScannedFiles++;
 				}
 			}
+			if (monitor.isCanceled()) {
+				fFatalError = true;
+				return Status.CANCEL_STATUS;
+			}
 			return Status.OK_STATUS;
 		}
 
@@ -525,7 +529,7 @@ public class TextSearchVisitor {
 				}
 			}
 			// Periodically check for cancellation and quit working on the current file if the job has been cancelled.
-			if (++k % 20 == 0 && monitor.isCanceled()) {
+			if (k++ % 20 == 0 && monitor.isCanceled()) {
 				break;
 			}
 		}


### PR DESCRIPTION
- Allow to cancel between(!) files and
- after the first(!) (and every 20th) hit inside a file.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=541178
