### PR TITLE
Unhide "enable word wrap" global preference UI (#67)

### DIFF
--- a/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.14.300.qualifier
+Bundle-Version: 3.14.400.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.ui.editors/plugin.properties
+++ b/org.eclipse.ui.editors/plugin.properties
@@ -129,6 +129,7 @@ preferenceKeywords.accessibility= accessibility caret cursor quick diff text edi
 preferenceKeywords.spelling= spelling spell checking dictionary correction check text editor
 preferenceKeywords.linkedmode= editor linked mode template
 preferenceKeywords.hyperlinkDetectors= hyperlinking text editor on demand link navigation modifier key
+preferenceKeywords.wordWrap= word wrap wordwrap wrapping wordwrapping soft text line break linebreak
 
 #--- linked mode annotations
 linked.focus.label= Current range

--- a/org.eclipse.ui.editors/plugin.xml
+++ b/org.eclipse.ui.editors/plugin.xml
@@ -287,6 +287,7 @@
             <keywordReference id="org.eclipse.ui.editors.lineNumber"/>
             <keywordReference id="org.eclipse.ui.editors.printMargin"/>
             <keywordReference id="org.eclipse.ui.editors.annotationCodeMining"/>
+            <keywordReference id="org.eclipse.ui.editors.wordWrap"/>
       </page>
       <page
             name="%PreferencePages.Annotations"
@@ -367,6 +368,9 @@
       <keyword
             label="%preferenceKeywords.hyperlinkDetectors"
             id="org.eclipse.ui.editors.hyperlinkDetectors"/>
+      <keyword
+            label="%preferenceKeywords.wordWrap"
+            id="org.eclipse.ui.editors.wordWrap"/>
    </extension>
    <extension
          point="org.eclipse.ui.editors.documentProviders">

--- a/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorDefaultsPreferencePage.java
+++ b/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorDefaultsPreferencePage.java
@@ -852,11 +852,9 @@ public class TextEditorDefaultsPreferencePage extends PreferencePage implements 
 		IntegerDomain tabWidthDomain= new IntegerDomain(1, 16);
 		addTextField(appearanceComposite, tabWidth, tabWidthDomain, 15, 0);
 
-		if(isWordWrapPreferenceAllowed()){
-			label= TextEditorMessages.TextEditorPreferencePage_enableWordWrap;
-			Preference enableWordWrap= new Preference(AbstractTextEditor.PREFERENCE_WORD_WRAP_ENABLED, label, null);
-			addCheckBox(appearanceComposite, enableWordWrap, new BooleanDomain(), 0);
-		}
+		label= TextEditorMessages.TextEditorPreferencePage_enableWordWrap;
+		Preference enableWordWrap= new Preference(AbstractTextEditor.PREFERENCE_WORD_WRAP_ENABLED, label, null);
+		addCheckBox(appearanceComposite, enableWordWrap, new BooleanDomain(), 0);
 
 		label= TextEditorMessages.TextEditorPreferencePage_convertTabsToSpaces;
 		Preference spacesForTabs= new Preference(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SPACES_FOR_TABS, label, null);
@@ -1117,10 +1115,6 @@ public class TextEditorDefaultsPreferencePage extends PreferencePage implements 
 		Table fAppearanceColorTable= fAppearanceColorTableViewer.getTable();
 		gd.heightHint= fAppearanceColorTable.getItemHeight() * 8;
 		fAppearanceColorTable.setLayoutData(gd);
-	}
-
-	private boolean isWordWrapPreferenceAllowed() {
-		return Boolean.getBoolean("eclipse.show.wrapByDefaultPreference"); //$NON-NLS-1$
 	}
 
 	@Override


### PR DESCRIPTION
This reverts changes made for bug
https://bugs.eclipse.org/bugs/show_bug.cgi?id=488162 which were made
because of concerns related to the performance of the Zoom in/Zoom Out
and scroll operations in huge text files with word wrap enabled (see
details in https://bugs.eclipse.org/bugs/show_bug.cgi?id=484142).

6 years and few releases later (4.6 -> 4.25) I can't observe significant
issues anymore, so let user decide if the word wrap should be always
enabled or not on opening editors (it can still be switched off).

Fixes https://github.com/eclipse-platform/eclipse.platform.text/issues/67