### PR TITLE
Improve Search progress text to show human readable text

### DIFF
--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchQuery.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchQuery.java
@@ -253,7 +253,7 @@ public class FileSearchQuery implements ISearchQuery {
 	public String getLabel() {
 		Pattern searchPattern = getSearchPattern();
 		return searchPattern.pattern().isEmpty() ? SearchMessages.FileSearchQuery_label
-				: Messages.format(SearchMessages.TextSearchVisitor_textsearch_task_label, searchPattern.pattern());
+				: Messages.format(SearchMessages.TextSearchVisitor_textsearch_task_label, getSearchString());
 	}
 
 	public String getSearchString() {


### PR DESCRIPTION
Searching for pattern 'searchtext' instead of '\Qsearchtext\E'
