### PR TITLE
Revert "bug 577511 - do not ignore cancel (#4)" (#64)

### DIFF
--- a/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -89,7 +89,6 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
@@ -4901,10 +4900,6 @@ public abstract class AbstractTextEditor extends EditorPart implements ITextEdit
 
 		} catch (CoreException x) {
 			IStatus status= x.getStatus();
-			if (status != null && status.getSeverity() == IStatus.CANCEL) {
-				// bug 577511 - do not ignore cancel:
-				throw new OperationCanceledException();
-			}
 			if (status == null || status.getSeverity() != IStatus.CANCEL) {
 				Bundle bundle= Platform.getBundle(PlatformUI.PLUGIN_ID);
 				ILog log= Platform.getLog(bundle);


### PR DESCRIPTION
This reverts commit 0f409d6f3d6b590242268c9d97c3a0107737dfa7.

Reason for revert: the original issue still there, but additionally we
have unhandled event loop exception.

Fixes https://github.com/eclipse-platform/eclipse.platform.text/issues/65