### PR TITLE
fix StringIndexOutOfBoundsException during File Search #79

### DIFF
--- a/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
If same search is started in parallel.
java.util.regex.Matcher is not thread-safe.