### PR TITLE
File search: Reliable and fast cancel

### DIFF
--- a/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
@@ -134,7 +134,6 @@ public final class SearchMessages extends NLS {
 	public static String TextSearchPage_searchBinary_label;
 	public static String TextSearchVisitor_filesearch_task_label;
 	public static String TextSearchVisitor_patterntoocomplex0;
-	public static String TextSearchVisitor_progress_updating_job;
 	public static String TextSearchVisitor_scanning;
 	public static String TextSearchVisitor_error;
 	public static String TextSearchVisitor_canceled;

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -106,9 +106,8 @@ TextSearchVisitor_error= File ''{1}'' has been skipped, problem while reading: (
 TextSearchVisitor_canceled= Operation Canceled
 TextSearchVisitor_unsupportedcharset=File ''{1}'' has been skipped: Unsupported encoding ''{0}''.
 TextSearchVisitor_patterntoocomplex0=Search pattern is too complex. Search canceled.
-TextSearchVisitor_progress_updating_job=Search progress polling
 TextSearchVisitor_filesearch_task_label=Searching for files...
-TextSearchVisitor_textsearch_task_label=Searching for pattern ''{0}''...
+TextSearchVisitor_textsearch_task_label=Searching ''{0}''
 TextSearchVisitor_illegalcharset=File ''{1}'' has been skipped: Illegal encoding ''{0}''.
 
 SortDropDownAction_label= S&ort By


### PR DESCRIPTION
File search did not cancel it's worker jobs if the user canceled before
the monitorUpdateJob was running (scheduling it is no guarantee that is
already running).
* monitor job is now incorporated into the search thread.
* fixed expected number of files to scan
* do not exit search thread before all workers finished.
* cancel search if any of the workers canceled
* forward cancel immediately (do not wait 100ms)