### PR TITLE
Make AbstractLineTracker thread safe (#91)

### DIFF
--- a/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 


### PR DESCRIPTION
Change that introduced DocumentRewriteSession was not thread safe.

Code that modified document via set() or replace() in parallel with other thread working in startRewriteSession()/startRewriteSession()/flushRewriteSession() could run in troubles.