### PR TITLE
fix testCompleteActivationChar to not fail other test #75

### DIFF
--- a/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/AsyncContentAssistTest.java
+++ b/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/AsyncContentAssistTest.java
@@ -156,6 +156,10 @@ public class AsyncContentAssistTest {
 		display.timerExec(200, new Runnable() {
 			@Override
 			public void run() {
+				if (control.isDisposed()) {
+					// https://github.com/eclipse-platform/eclipse.platform.text/issues/75#issuecomment-1263429480
+					return; // do not fail other unit tests
+				}
 				control.forceFocus();
 				keyEvent.widget= control;
 				keyEvent.type= SWT.KeyDown;


### PR DESCRIPTION
testSyncFailureNPE failed because of late event handling