### PR TITLE
fix CodeMiningProjectionViewerTest.testCodeMiningDoesntAlterFocus() #34

### DIFF
--- a/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -88,6 +88,10 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 	 *         label and <code>false</code> otherwise.
 	 */
 	private boolean hasAtLeastOneResolvedMiningNotEmpty() {
+		if (fMinings.stream().anyMatch(m -> m.getLabel() != null)) {
+			return true; // will have a resolved mining.
+		}
+
 		if (fResolvedMinings == null || fResolvedMinings.length == 0) {
 			return false;
 		}


### PR DESCRIPTION
fResolvedMinings is filled only after draw.