### PR TITLE
Bump o.e.jface.text version to 3.22

### DIFF
--- a/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.21.100.qualifier
+Bundle-Version: 3.22.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/link/LinkedModeUI.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/link/LinkedModeUI.java
@@ -290,7 +290,7 @@ public class LinkedModeUI {
 		 * @param model the linked mode model
 		 * @param event the document event
 		 * @return valid exit flags or <code>null</code> if no special action should be taken
-		 * @since 3.21
+		 * @since 3.22
 		 */
 		default ExitFlags doExit(LinkedModeModel model, DocumentEvent event) {
 			return null;


### PR DESCRIPTION
Previous change on LinkedModeUI.doExit actually added some API and should have triggered a version bump (but wasn't detected by API Tools).