### PR TITLE
Filter out org.eclipse.jface.text version warning

### DIFF
--- a/org.eclipse.jface.text/.settings/.api_filters
+++ b/org.eclipse.jface.text/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jface.text" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="See https://github.com/eclipse-pde/eclipse.pde/issues/411 , applied to addition of IExitPolicy.doExit(...) addition" id="926941240">
+            <message_arguments>
+                <message_argument value="3.22.0"/>
+                <message_argument value="3.21.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/jface/text/link/LinkedModeUI.java" type="org.eclipse.jface.text.link.LinkedModeUI$IExitPolicy">
         <filter comment="A new default IExitPolicy.doExit(LinkedModeModel model, DocumentEvent event)  method is added. Despite the fact that the interface is implementable by Clients and https://wiki.eclipse.org/Evolving_Java-based_APIs_2#Evolving_API_Interfaces say that such a change may 'break compatibility',  we don't know any such client that may implement such a method at present, so we believe this change will NOT add any compatibility break." id="404000815">
             <message_arguments>


### PR DESCRIPTION
An API was effectively added, LinkedModeUI$IExitPolicy.doExit, but some other filter are necessary and make API tool miss this