### PR TITLE
Test fix: focus shell before focusing button

### DIFF
--- a/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jface.text.tests
-Bundle-Version: 3.12.600.qualifier
+Bundle-Version: 3.12.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/ContextInformationTest.java
+++ b/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/ContextInformationTest.java
@@ -112,6 +112,7 @@ public class ContextInformationTest extends AbstractContentAssistTest {
 		assertEquals("idx= 1", getInfoText(this.infoShell));
 
 		// Hide all
+		getButton().getShell().setFocus();
 		getButton().setFocus();
 		processEvents();
 		assertTrue(this.infoShell.isDisposed() || !this.infoShell.isVisible());


### PR DESCRIPTION
After https://github.com/eclipse-platform/eclipse.platform.swt/pull/451 focusing widget in a Shell that is not focused does nothing.

The test created new shells, and focused a button from original one - this doesn't work anymore. Fix the test to focus the expected shell first.

See https://github.com/eclipse-platform/eclipse.platform.swt/issues/502