### PR TITLE
Revert "Test fix: focus shell before focusing button"

### DIFF
--- a/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/ContextInformationTest.java
+++ b/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/ContextInformationTest.java
@@ -112,7 +112,6 @@ public class ContextInformationTest extends AbstractContentAssistTest {
 		assertEquals("idx= 1", getInfoText(this.infoShell));
 
 		// Hide all
-		getButton().getShell().setFocus();
 		getButton().setFocus();
 		processEvents();
 		assertTrue(this.infoShell.isDisposed() || !this.infoShell.isVisible());


### PR DESCRIPTION
This reverts commit 01906e9811dcfde3a1c1a995230c4ef5dd0a216b as the original SWT change was reverted too via
https://github.com/eclipse-platform/eclipse.platform.swt/pull/503.