### PR TITLE
Fix problem with empty code minings being shown

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2017 Angelo ZERR.
+ *  Copyright (c) 2017, 2022 Angelo ZERR.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,7 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 	 *         label and <code>false</code> otherwise.
 	 */
 	private boolean hasAtLeastOneResolvedMiningNotEmpty() {
-		if (fMinings.stream().anyMatch(m -> m.getLabel() != null)) {
+		if (fMinings.stream().anyMatch(m -> m.getLabel() != null && !m.getLabel().isEmpty())) {
 			return true; // will have a resolved mining.
 		}
 


### PR DESCRIPTION
- fix CodeMiningLineHeaderAnnotation to add check for mining label being empty
- fixes #131