### PR TITLE
Fix alignment of preference field labels

### DIFF
--- a/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchPreferencesPage.java
+++ b/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchPreferencesPage.java
@@ -20,6 +20,7 @@ import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.text.quicksearch.internal.core.preferences.QuickSearchPreferences;
 import org.eclipse.ui.IWorkbench;
@@ -85,6 +86,12 @@ public class QuickSearchPreferencesPage extends FieldEditorPreferencePage implem
 					GridData layout = (GridData) text.getLayoutData();
 					layout.widthHint = 400;
 					layout.minimumWidth = 100;
+					// align label on top because the text widgets are higher than 1 line
+					Label label = getLabelControl();
+					layout = new GridData();
+					layout.verticalAlignment = SWT.TOP;
+					layout.verticalIndent = 3;
+					label.setLayoutData(layout);
 				}
 			};
 			addField(field);


### PR DESCRIPTION
The text fields are higher than one line of text, therefore their labels should be aligned at the top, not at the vertical center.
before:
![grafik](https://user-images.githubusercontent.com/406876/213934703-eb2e1f21-2721-4b63-99ef-57c6a9031dc7.png)

after:
![grafik](https://user-images.githubusercontent.com/406876/213934718-11ff3252-eb98-49ad-9ed8-6d95dcec2f61.png)
