### PR TITLE
add always default folding reconciler

### DIFF
--- a/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor;singleton:=true
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",

--- a/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -272,9 +272,10 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 				foldingReconcilingStrategies, getContentTypes(sourceViewer.getDocument()));
 		if (!foldingReconcilers.isEmpty()) {
 			reconcilers.addAll(foldingReconcilers);
-		} else if (foldingReconcilingStrategies.isEmpty()) {
-			reconcilers.add(new DefaultFoldingReconciler());
 		}
+		// add default reconciler:
+		reconcilers.add(new DefaultFoldingReconciler());
+		
 		reconcilingStrategies.addAll(foldingReconcilingStrategies);
 
 		if (!reconcilingStrategies.isEmpty()) {


### PR DESCRIPTION
This enables folding in the generic text editor if the contributed folding reconciler cannot be applied e.g. LSP server does not provide folding support. Folding settings of several reconcilers will be applied to the viewer.

Background: see [LSP4E issue 410](https://github.com/eclipse/lsp4e/issues/410)