### PR TITLE
Add filtering support for duplicate files in nested projects

### DIFF
--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     Christian Walther (Indel AG) - Bug 399094: Add whole word option to file search
  *     Marco Descher <marco@descher.at> - Open Search dialog with previous page instead of using the current selection to detect the page - http://bugs.eclipse.org/33710
  *     Lucas Bullen (Red Hat Inc.) - [Bug 526453] disambiguate "Selected Resources"
+ *     Red Hat Inc. - add support for filtering innermost project files for file search
  *******************************************************************************/
 package org.eclipse.search.internal.ui;
 
@@ -127,6 +128,9 @@ public final class SearchMessages extends NLS {
 	public static String SearchPage_regularExpression;
 	public static String SearchPage_wholeWord;
 	public static String TextSearchEngine_statusMessage;
+	public static String TextSearchInnermostProjectFilter_action_label;
+	public static String TextSearchInnermostProjectFilter_name;
+	public static String TextSearchInnermostProjectFilter_description;
 	public static String TextSearchPage_replace_querycreationproblem_message;
 	public static String TextSearchPage_replace_runproblem_message;
 	public static String TextSearchPage_searchIn_label;
@@ -172,6 +176,8 @@ public final class SearchMessages extends NLS {
 	public static String FileSearchPage_sort_by_label;
 	public static String FileSearchPage_limited_format_files;
 	public static String FileSearchPage_limited_format_matches;
+	public static String FileSearchPage_filtered_message;
+	public static String FileSearchPage_filteredWithCount_message;
 	public static String WorkspaceScope;
 	public static String ScopePart_group_text;
 	public static String ScopePart_selectedResourcesScope_text;

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -98,7 +98,7 @@ SearchPage_wholeWord= Who&le word
 TextSearchEngine_statusMessage= Problems encountered during text search.
 
 TextSearchInnermostProjectFilter_action_label=Show only most &nested match
-TextSearchInnermostProjectFilter_name= Nested project duplicates
+TextSearchInnermostProjectFilter_name=Duplicate match from outer project
 TextSearchInnermostProjectFilter_description= For files in nested projects, don't show matches for duplicate file references that are owned by projects that aren't the innermost project.
 TextSearchPage_searchIn_label=Search In
 TextSearchPage_searchDerived_label=Deri&ved resources

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -97,7 +97,7 @@ SearchPage_wholeWord= Who&le word
 
 TextSearchEngine_statusMessage= Problems encountered during text search.
 
-TextSearchInnermostProjectFilter_action_label= &Nested project duplicates
+TextSearchInnermostProjectFilter_action_label=Show only most &nested match
 TextSearchInnermostProjectFilter_name= Nested project duplicates
 TextSearchInnermostProjectFilter_description= For files in nested projects, don't show matches for duplicate file references that are owned by projects that aren't the innermost project.
 TextSearchPage_searchIn_label=Search In

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2017 IBM Corporation and others.
+# Copyright (c) 2000, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -97,6 +97,9 @@ SearchPage_wholeWord= Who&le word
 
 TextSearchEngine_statusMessage= Problems encountered during text search.
 
+TextSearchInnermostProjectFilter_action_label= &Nested project duplicates
+TextSearchInnermostProjectFilter_name= Nested project duplicates
+TextSearchInnermostProjectFilter_description= For files in nested projects, don't show matches for duplicate file references that are owned by projects that aren't the innermost project.
 TextSearchPage_searchIn_label=Search In
 TextSearchPage_searchDerived_label=Deri&ved resources
 TextSearchPage_searchBinary_label=&Binary files
@@ -180,6 +183,8 @@ FileSearchPage_sort_by_label=Sort By
 FileSearchPage_limited_format_files={0} (showing {1} of {2} files)
 FileSearchPage_limited_format_matches={0} (showing {1} of {2} matches)
 FileSearchPage_open_file_dialog_title=Open File
+FileSearchPage_filtered_message={0} (Filtered)
+FileSearchPage_filteredWithCount_message={0} ({1} matches filtered from view)
 
 WorkspaceScope= workspace
 

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchResult.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileSearchResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,8 +10,12 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc. - add support for filtering files from innermost nested projects
  *******************************************************************************/
 package org.eclipse.search.internal.ui.text;
+
+import java.util.HashSet;
+import java.util.StringTokenizer;
 
 import org.eclipse.core.resources.IFile;
 
@@ -21,12 +25,14 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 
+import org.eclipse.search.internal.ui.SearchPlugin;
 import org.eclipse.search.internal.ui.SearchPluginImages;
 import org.eclipse.search.ui.ISearchQuery;
 import org.eclipse.search.ui.text.AbstractTextSearchResult;
 import org.eclipse.search.ui.text.IEditorMatchAdapter;
 import org.eclipse.search.ui.text.IFileMatchAdapter;
 import org.eclipse.search.ui.text.Match;
+import org.eclipse.search.ui.text.MatchFilter;
 
 public class FileSearchResult extends AbstractTextSearchResult implements IEditorMatchAdapter, IFileMatchAdapter {
 	private final Match[] EMPTY_ARR= new Match[0];
@@ -35,18 +41,86 @@ public class FileSearchResult extends AbstractTextSearchResult implements IEdito
 
 	public FileSearchResult(FileSearchQuery job) {
 		fQuery= job;
+		setActiveMatchFilters(getLastUsedFilters());
 	}
+
 	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return SearchPluginImages.DESC_OBJ_TSEARCH_DPDN;
 	}
+
 	@Override
 	public String getLabel() {
 		return fQuery.getResultLabel(getMatchCount());
 	}
+
 	@Override
 	public String getTooltip() {
 		return getLabel();
+	}
+
+	private static MatchFilter INNERMOST_PROJECT = new OuterProjectFileFilter();
+	private static MatchFilter[] ALL_MATCH_FILTERS = new MatchFilter[] { INNERMOST_PROJECT };
+	private static final String SETTINGS_LAST_USED_FILTERS = "filters_last_used"; //$NON-NLS-1$
+
+	@Override
+	public MatchFilter[] getAllMatchFilters() {
+		return ALL_MATCH_FILTERS;
+	}
+
+	@Override
+	public synchronized void setActiveMatchFilters(MatchFilter[] filters) {
+		// TODO Auto-generated method stub
+		super.setActiveMatchFilters(filters);
+		setLastUsedFilters(filters);
+	}
+
+	@Override
+	public synchronized MatchFilter[] getActiveMatchFilters() {
+		// TODO Auto-generated method stub
+		return super.getActiveMatchFilters();
+	}
+
+	public static MatchFilter[] getLastUsedFilters() {
+		String string = SearchPlugin.getDefault().getDialogSettings().get(SETTINGS_LAST_USED_FILTERS);
+		if (string != null) {
+			return decodeFiltersString(string);
+		}
+		return new MatchFilter[0];
+	}
+
+	public static void setLastUsedFilters(MatchFilter[] filters) {
+		String encoded = encodeFilters(filters);
+		SearchPlugin.getDefault().getDialogSettings().put(SETTINGS_LAST_USED_FILTERS, encoded);
+	}
+
+	private static String encodeFilters(MatchFilter[] enabledFilters) {
+		StringBuilder buf = new StringBuilder();
+		for (MatchFilter matchFilter : enabledFilters) {
+			buf.append(matchFilter.getID());
+			buf.append(';');
+		}
+		return buf.toString();
+	}
+
+	private static MatchFilter[] decodeFiltersString(String encodedString) {
+		StringTokenizer tokenizer = new StringTokenizer(encodedString, String.valueOf(';'));
+		HashSet<MatchFilter> result = new HashSet<>();
+		while (tokenizer.hasMoreTokens()) {
+			MatchFilter curr = findMatchFilter(tokenizer.nextToken());
+			if (curr != null) {
+				result.add(curr);
+			}
+		}
+		return result.toArray(new MatchFilter[result.size()]);
+	}
+
+	private static MatchFilter findMatchFilter(String id) {
+		for (MatchFilter matchFilter : ALL_MATCH_FILTERS) {
+			if (matchFilter.getID().equals(id))
+				return matchFilter;
+		}
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileTableContentProvider.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileTableContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,8 +10,12 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc. - add support to filter files from non-innermost nested projects
  *******************************************************************************/
 package org.eclipse.search.internal.ui.text;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.TableViewer;
@@ -35,15 +39,36 @@ public class FileTableContentProvider implements IStructuredContentProvider, IFi
 		// nothing to do
 	}
 
+	public Object[] getUnfilteredElements(AbstractTextSearchResult searchResult) {
+		int elementLimit = getElementLimit();
+		Object[] elements = searchResult.getElements();
+		if (elementLimit != -1 && elements.length > elementLimit) {
+			Object[] shownElements = new Object[elementLimit];
+			System.arraycopy(elements, 0, shownElements, 0, elementLimit);
+			return shownElements;
+		}
+		return elements;
+	}
+
 	@Override
 	public Object[] getElements(Object inputElement) {
 		if (inputElement instanceof FileSearchResult) {
+			FileSearchResult fileSearchResult = (FileSearchResult) inputElement;
 			int elementLimit= getElementLimit();
-			Object[] elements= ((FileSearchResult)inputElement).getElements();
+			Object[] elements = fileSearchResult.getElements();
 			if (elementLimit != -1 && elements.length > elementLimit) {
 				Object[] shownElements= new Object[elementLimit];
 				System.arraycopy(elements, 0, shownElements, 0, elementLimit);
 				return shownElements;
+			}
+			if (fileSearchResult.getActiveMatchFilters().length > 0) {
+				List<Object> elementList = new ArrayList<>();
+				for (Object element : elements) {
+					if (fPage.getDisplayedMatchCount(element) > 0) {
+						elementList.add(element);
+					}
+				}
+				elements = elementList.toArray();
 			}
 			return elements;
 		}
@@ -63,7 +88,7 @@ public class FileTableContentProvider implements IStructuredContentProvider, IFi
 		int elementLimit= getElementLimit();
 		boolean tableLimited= elementLimit != -1;
 		for (Object updatedElement : updatedElements) {
-			if (fResult.getMatchCount(updatedElement) > 0) {
+			if (fPage.getDisplayedMatchCount(updatedElement) > 0) {
 				if (viewer.testFindItem(updatedElement) != null)
 					viewer.update(updatedElement, null);
 				else {

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/text/OuterProjectFileFilter.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/text/OuterProjectFileFilter.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial implementation
+ *******************************************************************************/
+package org.eclipse.search.internal.ui.text;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Comparator;
+
+import org.eclipse.core.resources.IFile;
+
+import org.eclipse.search.internal.ui.SearchMessages;
+import org.eclipse.search.ui.text.Match;
+import org.eclipse.search.ui.text.MatchFilter;
+
+public class OuterProjectFileFilter extends MatchFilter {
+
+	@Override
+	public boolean filters(Match match) {
+		if (match instanceof FileMatch) {
+			IFile file= ((FileMatch)match).getFile();
+			URI locationUri = file.getLocationURI();
+			IFile innermostFile = locationUri == null ? file : //
+					Arrays.stream(file.getWorkspace().getRoot().findFilesForLocationURI(locationUri)) //
+							.min(Comparator.comparingInt(aFile -> aFile.getFullPath().segments().length))
+							// shortest workspace (project relative) full path
+							// means most nested project
+							.orElse(file);
+			return !file.equals(innermostFile);
+		}
+		return false;
+	}
+
+	@Override
+	public String getName() {
+		return SearchMessages.TextSearchInnermostProjectFilter_name;
+	}
+
+	@Override
+	public String getDescription() {
+		return SearchMessages.TextSearchInnermostProjectFilter_description;
+	}
+
+	@Override
+	public String getActionLabel() {
+		return SearchMessages.TextSearchInnermostProjectFilter_action_label;
+	}
+
+	@Override
+	public String getID() {
+		return "filter_innermost_project"; //$NON-NLS-1$
+	}
+
+}


### PR DESCRIPTION
- add filter to File Search to remove duplicate file entries that are attributed to different projects in a nested project scenario
- fixes #143