### PR TITLE
Improve Generic Editor FoldingTest so it can handle async change to

### DIFF
--- a/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor.tests;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.genericeditor.tests,


### PR DESCRIPTION
folding

The folding provider is going to become more reactive, so we improve it a bit
to allow async folding info.