### PR TITLE
Fix ClassCastException in TextSearchVisitor.TextSearchJob

### DIFF
--- a/org.eclipse.search/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -223,8 +223,8 @@ public class TextSearchVisitor {
 						}
 						occurences = locateMatches(file, charsequence, matcher, monitor);
 					} catch (FileCharSequenceProvider.FileCharSequenceException e) {
-						if (e.getCause() instanceof RuntimeException) {
-							throw (RuntimeException) e.getCause();
+						if (e.getCause() instanceof RuntimeException runtimeEx) {
+							throw runtimeEx;
 						}
 						throw e;
 					}

--- a/org.eclipse.search/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -223,7 +223,10 @@ public class TextSearchVisitor {
 						}
 						occurences = locateMatches(file, charsequence, matcher, monitor);
 					} catch (FileCharSequenceProvider.FileCharSequenceException e) {
-						throw (RuntimeException) e.getCause();
+						if (e.getCause() instanceof RuntimeException) {
+							throw (RuntimeException) e.getCause();
+						}
+						throw e;
 					}
 				}
 				fCollector.flushMatches(file);


### PR DESCRIPTION
- TextSearchVisitor.TextSearchJob.processFile() has a catch for FileCharSequenceProvider.FileCharSequenceException and tries to rethrow the exception cause.  In the case where the cause is an IOException, throw the original FileCharSequenceException which is a RuntimeException
- discovered by https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/436