### PR TITLE
Remove AnnotationRulerColumn code added for bug 531952

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationRulerColumn.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationRulerColumn.java
@@ -45,12 +45,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
-import org.eclipse.jface.text.ITextListener;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITextViewerExtension5;
 import org.eclipse.jface.text.JFaceTextUtil;
 import org.eclipse.jface.text.Position;
-import org.eclipse.jface.text.TextEvent;
 
 
 /**
@@ -186,20 +184,6 @@ public class AnnotationRulerColumn implements IVerticalRulerColumn, IVerticalRul
 
 	private Consumer<StyledText> lineHeightChangeHandler= t -> postRedraw();
 
-	private ITextListener fLineListener = new ITextListener() {
-		private int previousLineCount = -1;
-
-		@Override
-		public void textChanged(TextEvent event) {
-			fCachedTextWidget.getDisplay().execute(() -> {
-				if (event.getViewerRedrawState() && fCachedTextWidget.getLineCount() != previousLineCount) {
-					previousLineCount= fCachedTextWidget.getLineCount();
-					postRedraw();
-				}
-			});
-		}
-	};
-
 	/**
 	 * Constructs this column with the given arguments.
 	 *
@@ -330,7 +314,6 @@ public class AnnotationRulerColumn implements IVerticalRulerColumn, IVerticalRul
 
 		if (fCachedTextViewer != null) {
 			VisibleLinesTracker.track(fCachedTextViewer, lineHeightChangeHandler);
-			fCachedTextViewer.addTextListener(fLineListener);
 			// on word wrap toggle a "resized" ControlEvent is fired: suggest a redraw of the ruler
 			fCachedTextWidget.addControlListener(new ControlAdapter() {
 				@Override
@@ -499,7 +482,6 @@ public class AnnotationRulerColumn implements IVerticalRulerColumn, IVerticalRul
 
 		if (fCachedTextViewer != null) {
 			VisibleLinesTracker.untrack(fCachedTextViewer, lineHeightChangeHandler);
-			fCachedTextViewer.removeTextListener(fLineListener);
 		}
 
 		if (fModel != null)


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=531952 for original issue.

The code (text change listener) that was added to AnnotationRulerColumn to fix bug 531952 can be simply commented out without any visible regression.

Let's remove this code, it adds unneeded complexity & is inconsistent with the rest of the text listeners code that is supposed to be used from UI thread only.

Fixes https://github.com/eclipse-platform/eclipse.platform.text/issues/177