### PR TITLE
brackets highlighting should not contains code mining text #47

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/source/MatchingCharacterPainter.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/source/MatchingCharacterPainter.java
@@ -245,28 +245,23 @@ public final class MatchingCharacterPainter implements IPainter, PaintListener {
 	 * @param gc the GC to draw into or <code>null</code> to send a redraw request
 	 * @param offset the offset of the widget region
 	 */
-	private void draw(GC gc, int offset) {
-		int length = 1;
+	private void draw(final GC gc, final int offset) {
 		if (gc != null) {
-
 			gc.setForeground(fColor);
 
-			Rectangle bounds= fTextWidget.getTextBounds(offset, offset + length - 1);
-			int height= fTextWidget.getCaret().getSize().y;
+			final Rectangle bounds= fTextWidget.getTextBounds(offset, offset);
+
+			// determine the character width separately, because the getTextBounds above
+			// will also include any in-line annotations (e.g. codemining annotations) in the width
+			final String matchingCharacter= fTextWidget.getText(offset, offset);
+			final int width= gc.textExtent(matchingCharacter).x;
+
+			final int height= fTextWidget.getCaret().getSize().y;
 
 			// draw box around line segment
-			gc.drawRectangle(bounds.x, bounds.y + bounds.height - height, bounds.width - 1, height - 1);
-
-			// draw box around character area
-//			int widgetBaseline= fTextWidget.getBaseline();
-//			FontMetrics fm= gc.getFontMetrics();
-//			int fontBaseline= fm.getAscent() + fm.getLeading();
-//			int fontBias= widgetBaseline - fontBaseline;
-
-//			gc.drawRectangle(left.x, left.y + fontBias, right.x - left.x - 1, fm.getHeight() - 1);
-
+			gc.drawRectangle(bounds.x, bounds.y + bounds.height - height, width, height - 1);
 		} else {
-			fTextWidget.redrawRange(offset, length, true);
+			fTextWidget.redrawRange(offset, 1, true);
 		}
 	}
 


### PR DESCRIPTION
### Notes

`MatchingCharacterPainter` is using the `StyledText.getTextBounds()` method to determine the width of the highlight box to draw. This method calculates width based on runs of text, and thus includes the method parameter hints in that width.

This change instead moves to using `GC.textExtent()` to determine the width of text to highlight, ensuring that only the desired character is highlighted. The character width to highlight was already hard-coded to `1`, so now we just pull a single character of text from the desired offset, and pass it to `GC.textExtent()` to get its width.

### Testing

**Manual testing**

Tested on Windows, running in a normal window

![image](https://user-images.githubusercontent.com/2163121/232287883-de097d9f-89ec-4e8e-b468-e23126bdd798.png)

Tested on Windows, on a desktop with 200% font scaling enabled:

![image](https://user-images.githubusercontent.com/2163121/232288086-0ac4dcdf-c831-4289-9006-8794ebbcdc53.png)

**Unit testing**

I didn't find existing unit tests for `MatchingCharacterPainter`, and am not quite sure how one would implement such, though I'm very open to suggestions.