### PR TITLE
Hide the popup in async mode when there are no completions left

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -244,9 +244,10 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 						if (offset != fInvocationOffset || fComputedProposals != requestSpecificProposals) {
 							return;
 						}
+						boolean stillComputing= fComputedProposals.contains(computingProposal);
 						if (autoInsert
 								&& !autoActivated
-								&& !fComputedProposals.contains(computingProposal)
+								&& !stillComputing
 								&& fComputedProposals.size() == 1
 								&& remaining.get() == 0
 								&& canAutoInsert(fComputedProposals.get(0))) {
@@ -256,18 +257,17 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 							}
 							return;
 						}
-						if (!fComputedProposals.contains(computingProposal) && callback != null) {
+						if (!stillComputing && callback != null) {
 							callback.accept(fComputedProposals);
 						} else {
-							boolean stillComputing= fComputedProposals.contains(computingProposal);
 							boolean hasProposals= (stillComputing && fComputedProposals.size() > 1)
 									|| (!stillComputing && !fComputedProposals.isEmpty());
 
 							if ((autoActivated && hasProposals) || !autoActivated) {
 								setProposals(fComputedProposals, false);
 								displayProposals(true);
-							} else if (isValid(fProposalShell) && !fProposalShell.isVisible() && remaining.get() == 0) {
-								hide(); // we only tear down if the popup is not visible.
+							} else if (isValid(fProposalShell) && fProposalShell.isVisible() && remaining.get() == 0) {
+								hide(); // we only tear down if the popup is visible.
 							}
 						}
 					});


### PR DESCRIPTION
Fix bug a introduced in 78fc9f6f6566323c691f1fee1eb14de2f27e7d34 that prevented the popup from closing when there are were completions left.

In addition, create the variable stillComputing earlier so that it can be reused.