### PR TITLE
Use a custom ForkJoinWorkerThreadFactory in AsyncCompletionProposalPopup

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -376,7 +376,8 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 		List<CompletableFuture<List<ICompletionProposal>>> futures = new ArrayList<>(processors.size());
 		for (IContentAssistProcessor processor : processors) {
 			// Use a custom ForkJoinWorkerThreadFactory, to prevent issues with a
-			// potential SecurityManager, since the threads created by it get no permissions.
+			// potential SecurityManager. Threads created by ForkJoinPool.commonPool(),
+			// which is used in CompletableFuture.supplyAsync(), get no permissions.
 			ForkJoinPool commonPool= new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(),
 					pool -> new ForkJoinWorkerThread(pool) {
 						// anonymous subclass to access protected constructor

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -42,6 +44,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.core.runtime.SafeRunner;
 
 import org.eclipse.jface.contentassist.IContentAssistSubjectControl;
+import org.eclipse.jface.util.SafeRunnable;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
@@ -372,26 +375,37 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 		}
 		List<CompletableFuture<List<ICompletionProposal>>> futures = new ArrayList<>(processors.size());
 		for (IContentAssistProcessor processor : processors) {
-			futures.add(CompletableFuture.supplyAsync(() -> {
-				AtomicReference<List<ICompletionProposal>> result= new AtomicReference<>();
-				SafeRunner.run(() -> {
-					ICompletionProposal[] proposals= processor.computeCompletionProposals(fViewer, invocationOffset);
-					if (proposals == null) {
-						result.set(Collections.emptyList());
-					} else {
-						result.set(Arrays.asList(proposals));
-					}
-				});
-				List<ICompletionProposal> proposals= result.get();
-				if (proposals == null) { // an error occurred during computeCompletionProposal,
-					// possible improvement: give user feedback by returning an error "proposal" shown
-					// in completion popup and providing details
-					return Collections.emptyList();
-				}
-				return proposals;
-			}));
+			// Use a custom ForkJoinWorkerThreadFactory, to prevent issues with a
+			// potential SecurityManager, since the threads created by it get no permissions.
+			ForkJoinPool commonPool= new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(),
+					pool -> new ForkJoinWorkerThread(pool) {
+						// anonymous subclass to access protected constructor
+					}, null, false);
+			futures.add(CompletableFuture.supplyAsync(() -> this.getCompletionProposals(processor, invocationOffset), commonPool));
 		}
 		return futures;
+	}
+
+	private List<ICompletionProposal> getCompletionProposals(IContentAssistProcessor processor, int invocationOffset) {
+		AtomicReference<List<ICompletionProposal>> result= new AtomicReference<>();
+		SafeRunner.run(new SafeRunnable() {
+			@Override
+			public void run() throws Exception {
+				ICompletionProposal[] proposals= processor.computeCompletionProposals(fViewer, invocationOffset);
+				if (proposals == null) {
+					result.set(Collections.emptyList());
+				} else {
+					result.set(Arrays.asList(proposals));
+				}
+			}
+		});
+		List<ICompletionProposal> proposals= result.get();
+		if (proposals == null) { // an error occurred during computeCompletionProposal,
+			// possible improvement: give user feedback by returning an error "proposal" shown
+			// in completion popup and providing details
+			return Collections.emptyList();
+		}
+		return proposals;
 	}
 
 	private String getTokenContentType(int invocationOffset) throws BadLocationException {


### PR DESCRIPTION
### What it does
CompletableFuture.supplyAsync() is using the defaultForkJoinWorkerThreadFactory. In case a SecurityManager is installed, using the defaultForkJoinWorkerThreadFactory would result in worker threads with no permissions, which leads to not content assist in the java editor.

Use a custom ForkJoinWorkerThreadFactory implementation to work around this.

See also:
https://github.com/eclipse-platform/eclipse.platform/issues/294
https://github.com/eclipse-platform/eclipse.platform/pull/295

### How to test
1. Have any Eclipse-plugin that installs a SecurityManager. Use attached demo plugin [foo.bar.securitymanager.zip](https://github.com/eclipse-platform/eclipse.platform/files/10208024/foo.bar.securitymanager.zip) (Main Menu SecurityManager -> Install SecurityManager) or the following snippet:
```
Policy.getPolicy(); // init
Policy.setPolicy(new Policy() {
    @Override
    public boolean implies(ProtectionDomain domain, Permission permission) {
        return true;
    }
});
System.setSecurityManager(new SecurityManager());
```
3. Open a Java project and use the content assist (CTRL+space)
4. The content assist will not work