### PR TITLE
Shutdown ForkJoinPool after code completion is executed

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -374,19 +374,19 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 			return Collections.emptyList();
 		}
 		List<CompletableFuture<List<ICompletionProposal>>> futures = new ArrayList<>(processors.size());
-		for (IContentAssistProcessor processor : processors) {
-			// Use a custom ForkJoinWorkerThreadFactory, to prevent issues with a
-			// potential SecurityManager. Threads created by ForkJoinPool.commonPool(),
-			// which is used in CompletableFuture.supplyAsync(), get no permissions.
-			ForkJoinPool commonPool= new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(),
-					pool -> new ForkJoinWorkerThread(pool) {
-						// anonymous subclass to access protected constructor
-					}, null, false);
-			try {
+		// Use a custom ForkJoinWorkerThreadFactory, to prevent issues with a
+		// potential SecurityManager. Threads created by ForkJoinPool.commonPool(),
+		// which is used in CompletableFuture.supplyAsync(), get no permissions.
+		ForkJoinPool commonPool= new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(),
+				pool -> new ForkJoinWorkerThread(pool) {
+					// anonymous subclass to access protected constructor
+				}, null, false);
+		try {
+			for (IContentAssistProcessor processor : processors) {
 				futures.add(CompletableFuture.supplyAsync(() -> this.getCompletionProposals(processor, invocationOffset), commonPool));
-			} finally {
-				commonPool.shutdown();
 			}
+		} finally {
+			commonPool.shutdown();
 		}
 		return futures;
 	}

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -382,7 +382,11 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 					pool -> new ForkJoinWorkerThread(pool) {
 						// anonymous subclass to access protected constructor
 					}, null, false);
-			futures.add(CompletableFuture.supplyAsync(() -> this.getCompletionProposals(processor, invocationOffset), commonPool));
+			try {
+				futures.add(CompletableFuture.supplyAsync(() -> this.getCompletionProposals(processor, invocationOffset), commonPool));
+			} finally {
+				commonPool.shutdown();
+			}
 		}
 		return futures;
 	}


### PR DESCRIPTION
The created ForkJoinPool must be shutdown after the asynchronous code completion is completed. Otherwise every code completion will create a new pool and they will never be shutdown.

This is a fix for a bug introduced with #185 