### PR TITLE
AbstractInformationControl constructor for resizable + status text

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControl.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControl.java
@@ -104,6 +104,22 @@ public abstract class AbstractInformationControl implements IInformationControl,
 
 	/**
 	 * Creates an abstract information control with the given shell as parent.
+	 * The control will optionally show a status line with the given status field text.
+	 * <p>
+	 * <em>Important: Subclasses are required to call {@link #create()} at the end of their constructor.</em>
+	 * </p>
+	 *
+	 * @param parentShell the parent of this control's shell
+	 * @param statusFieldText the text to be used in the status field or <code>null</code> to hide the status field
+	 * @param resizable whether to make the control resizable
+	 * @since 3.24
+	 */
+	public AbstractInformationControl(Shell parentShell, String statusFieldText, boolean resizable) {
+		this(parentShell, SWT.TOOL | SWT.ON_TOP | (resizable ? SWT.RESIZE : 0), statusFieldText, null);
+	}
+
+	/**
+	 * Creates an abstract information control with the given shell as parent.
 	 * The control will not be resizable and optionally show a status line with
 	 * the given status field text.
 	 * <p>
@@ -114,7 +130,7 @@ public abstract class AbstractInformationControl implements IInformationControl,
 	 * @param statusFieldText the text to be used in the status field or <code>null</code> to hide the status field
 	 */
 	public AbstractInformationControl(Shell parentShell, String statusFieldText) {
-		this(parentShell, SWT.TOOL | SWT.ON_TOP | SWT.RESIZE, statusFieldText, null);
+		this(parentShell, statusFieldText, false);
 	}
 
 	/**

--- a/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",
  org.eclipse.ui.editors;bundle-version="3.14.0",
  org.eclipse.text;bundle-version="3.6.0",
- org.eclipse.jface.text;bundle-version="3.13.0",
+ org.eclipse.jface.text;bundle-version="3.24.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.ui.workbench;bundle-version="3.109.0",
  org.eclipse.jface;bundle-version="3.12.0",

--- a/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
+++ b/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
@@ -45,7 +45,7 @@ public class CompositeInformationControl extends AbstractInformationControl impl
 	LinkedHashMap<ITextHover, AbstractInformationControl> controls;
 
 	public CompositeInformationControl(Shell parentShell, LinkedHashMap<ITextHover, IInformationControlCreator> creators) {
-		super(parentShell, EditorsUI.getTooltipAffordanceString()); // TODO check best constructor
+		super(parentShell, EditorsUI.getTooltipAffordanceString(), true);
 		Assert.isLegal(creators.size() > 1, "Do not compose a unique hover"); //$NON-NLS-1$
 		this.creators = creators;
 		create();


### PR DESCRIPTION
and use this constructor in Generic Editor which needs this combination

This also removes the addition of SWT.RESIZE style on existing constructor while this constructor specifies that the control is not resizable.
The new constructor takes the resizable as parameter.