### PR TITLE
Revert "Hide the popup in async mode when there are no completions left"

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -244,10 +244,9 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 						if (offset != fInvocationOffset || fComputedProposals != requestSpecificProposals) {
 							return;
 						}
-						boolean stillComputing= fComputedProposals.contains(computingProposal);
 						if (autoInsert
 								&& !autoActivated
-								&& !stillComputing
+								&& !fComputedProposals.contains(computingProposal)
 								&& fComputedProposals.size() == 1
 								&& remaining.get() == 0
 								&& canAutoInsert(fComputedProposals.get(0))) {
@@ -257,17 +256,18 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 							}
 							return;
 						}
-						if (!stillComputing && callback != null) {
+						if (!fComputedProposals.contains(computingProposal) && callback != null) {
 							callback.accept(fComputedProposals);
 						} else {
+							boolean stillComputing= fComputedProposals.contains(computingProposal);
 							boolean hasProposals= (stillComputing && fComputedProposals.size() > 1)
 									|| (!stillComputing && !fComputedProposals.isEmpty());
 
 							if ((autoActivated && hasProposals) || !autoActivated) {
 								setProposals(fComputedProposals, false);
 								displayProposals(true);
-							} else if (isValid(fProposalShell) && fProposalShell.isVisible() && remaining.get() == 0) {
-								hide(); // we only tear down if the popup is visible.
+							} else if (isValid(fProposalShell) && !fProposalShell.isVisible() && remaining.get() == 0) {
+								hide(); // we only tear down if the popup is not visible.
 							}
 						}
 					});


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.text#183, as it causes the PopupVisibleTimer to be kept running when the last remaining proposal computation finishes.