### PR TITLE
Reverts #183, as it causes the PopupVisibleTimer to be kept running when

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AsyncCompletionProposalPopup.java
@@ -266,8 +266,8 @@ class AsyncCompletionProposalPopup extends CompletionProposalPopup {
 							if ((autoActivated && hasProposals) || !autoActivated) {
 								setProposals(fComputedProposals, false);
 								displayProposals(true);
-							} else if (isValid(fProposalShell) && fProposalShell.isVisible() && remaining.get() == 0) {
-								hide(); // we only tear down if the popup is visible.
+							} else if (isValid(fProposalShell) && (!fProposalShell.isVisible() || !hasProposals) && remaining.get() == 0) {
+								hide(); // we only tear down if the popup is not visible or it is visible but has no proposals.
 							}
 						}
 					});


### PR DESCRIPTION
the last remaining proposal computation finishes.

Instead the tear down is done either when it was not visible (as before #183) or when it was visible but there is no proposals to show.