### PR TITLE
Use less aggressive defaults

### DIFF
--- a/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.1.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",

--- a/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorContentAssistant.java
+++ b/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorContentAssistant.java
@@ -71,7 +71,7 @@ public class GenericEditorContentAssistant extends ContentAssistant {
 
 		setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_BELOW);
 		setProposalPopupOrientation(IContentAssistant.PROPOSAL_REMOVE);
-		setAutoActivationDelay(0);
+		setAutoActivationDelay(10);
 		enableColoredLabels(true);
 		enableAutoActivation(true);
 		enableAutoActivateCompletionOnType(true);


### PR DESCRIPTION
Both the JDT and VSCode do not trigger auto completion on each alphanumeric character by default. They only do it on trigger characters and only with a delay of 10 milliseconds.

This PR change the configuration of the Generic Editor to have the same defaults 