### PR TITLE
"Go to Matching Bracket" command: add missing label and description

### DIFF
--- a/org.eclipse.ui.genericeditor/plugin.properties
+++ b/org.eclipse.ui.genericeditor/plugin.properties
@@ -35,3 +35,5 @@ Bundle-Name=Generic and Extensible Text Editor
 command.toggle.highlight.label = Toggle Mark Occurences
 command.toggle.highlight.name = Toggle Highlight
 menu.source.label = Source
+gotoMatchingBracketCommand_name =  Go to Matching Bracket
+gotoMatchingBracketCommand_description = Moves the cursor to the matching bracket


### PR DESCRIPTION
Add the missing label and description for the _Go to Matching Bracket_ command