### PR TITLE
Remove unused private members

### DIFF
--- a/org.eclipse.core.filebuffers/src/org/eclipse/core/internal/filebuffers/FileStoreTextFileBuffer.java
+++ b/org.eclipse.core.filebuffers/src/org/eclipse/core/internal/filebuffers/FileStoreTextFileBuffer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2014 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,12 +31,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnmappableCharacterException;
 import java.nio.charset.UnsupportedCharsetException;
 
-import org.eclipse.osgi.util.NLS;
-
+import org.eclipse.core.filebuffers.IFileBufferStatusCodes;
+import org.eclipse.core.filebuffers.IPersistableAnnotationModel;
+import org.eclipse.core.filebuffers.ITextFileBuffer;
+import org.eclipse.core.filebuffers.LocationKind;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
-
+import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -48,18 +50,11 @@ import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.runtime.content.IContentType;
-
-import org.eclipse.core.resources.IResourceStatus;
-
-import org.eclipse.core.filebuffers.IFileBufferStatusCodes;
-import org.eclipse.core.filebuffers.IPersistableAnnotationModel;
-import org.eclipse.core.filebuffers.ITextFileBuffer;
-import org.eclipse.core.filebuffers.LocationKind;
-
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.osgi.util.NLS;
 
 /**
  * @since 3.3 (previously available as JavaTextFileBuffer since 3.3)
@@ -82,14 +77,6 @@ public class FileStoreTextFileBuffer extends FileStoreFileBuffer implements ITex
 		}
 	}
 
-	/**
-	 * Reader chunk size.
-	 */
-	private static final int READER_CHUNK_SIZE= 2048;
-	/**
-	 * Buffer size.
-	 */
-	private static final int BUFFER_SIZE= 8 * READER_CHUNK_SIZE;
 	/**
 	 * Constant for representing the error status. This is considered a value object.
 	 */


### PR DESCRIPTION
Reported at
https://download.eclipse.org/eclipse/downloads/drops4/I20230615-1800/compilelogs/plugins/org.eclipse.core.filebuffers_3.8.100.v20230614-0639/@dot.html which is listed in
https://download.eclipse.org/eclipse/downloads/drops4/I20230615-1800/testResults.php#PluginsErrors .
Introduced by
https://github.com/eclipse-platform/eclipse.platform.text/pull/224