### PR TITLE
Use new static IPath factories and constants

### DIFF
--- a/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.filebuffers.tests;x-internal:=true
 Require-Bundle: 
- org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)";resolution:=optional,
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/AbstractFileBufferDocCreationTests.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/AbstractFileBufferDocCreationTests.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.core.filebuffers.IDocumentSetupParticipantExtension;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
@@ -122,7 +122,7 @@ public abstract class AbstractFileBufferDocCreationTests {
 	private void assertParticipantsInvoked(String path, Class<?>[] expectedDSPsArray) {
 		LocationKind[] lks= getSupportLocationKinds();
 		for (LocationKind lk : lks) {
-			IDocument document = fManager.createEmptyDocument(new Path(path), lk);
+			IDocument document= fManager.createEmptyDocument(IPath.fromOSString(path), lk);
 			String content= document.get();
 			Set<String> expectedDSPs= new HashSet<>(Arrays.asList(toString(expectedDSPsArray)));
 			Set<String> actualDSPs= new HashSet<>(Arrays.asList(content.split("\n")));
@@ -133,7 +133,7 @@ public abstract class AbstractFileBufferDocCreationTests {
 	abstract protected LocationKind[] getSupportLocationKinds();
 
 	protected void assertDocumentContent(String expectedContent, String path, LocationKind locKind) {
-		assertEquals(expectedContent, fManager.createEmptyDocument(new Path(path), locKind).get());
+		assertEquals(expectedContent, fManager.createEmptyDocument(IPath.fromOSString(path), locKind).get());
 	}
 
 	private static String[] toString(Class<?>[] clss) {

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ConvertLineDelemiterTest.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ConvertLineDelemiterTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -63,7 +62,7 @@ public class ConvertLineDelemiterTest {
 				int i= 0;
 				for (String inputDelim : DELIMS) {
 					String input= testFile.apply(inputDelim);
-					IFile file= ResourcesPlugin.getWorkspace().getRoot().getFile(new Path("/ConvertLineDelemiterTest/test" + i + ".txt"));
+					IFile file= ResourcesPlugin.getWorkspace().getRoot().getFile(IPath.fromOSString("/ConvertLineDelemiterTest/test" + i + ".txt"));
 					try (InputStream s= new ByteArrayInputStream(input.getBytes())) {
 						file.create(s, true, null);
 					}

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferCreation.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferCreation.java
@@ -32,7 +32,6 @@ import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -71,12 +70,12 @@ public class FileBufferCreation {
 	}
 
 	private IPath createLinkedFile(String linkedFileName, String linkedFileTarget) throws CoreException {
-		IFile linkedFile= ResourceHelper.createLinkedFile(fProject, new Path(linkedFileName), FileBuffersTestPlugin.getDefault(), new Path(linkedFileTarget));
+		IFile linkedFile= ResourceHelper.createLinkedFile(fProject, IPath.fromOSString(linkedFileName), FileBuffersTestPlugin.getDefault(), IPath.fromOSString(linkedFileTarget));
 		return linkedFile.getFullPath();
 	}
 
 	private IPath createLinkedFolder(String linkedFolderName, String linkedFolderTarget) throws CoreException {
-		IFolder linkedFolder= ResourceHelper.createLinkedFolder(fProject, new Path(linkedFolderName), FileBuffersTestPlugin.getDefault(), new Path(linkedFolderTarget));
+		IFolder linkedFolder= ResourceHelper.createLinkedFolder(fProject, IPath.fromOSString(linkedFolderName), FileBuffersTestPlugin.getDefault(), IPath.fromOSString(linkedFolderTarget));
 		return linkedFolder.getFullPath();
 	}
 
@@ -281,9 +280,9 @@ public class FileBufferCreation {
 	 */
 	@Test
 	public void test5() throws Exception {
-		File externalFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/ExternalFile"));
+		File externalFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/ExternalFile"));
 		assertNotNull(externalFile);
-		IPath path= new Path(externalFile.getAbsolutePath());
+		IPath path= IPath.fromOSString(externalFile.getAbsolutePath());
 
 		ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
 		manager.connect(path, LocationKind.NORMALIZE, null);
@@ -309,9 +308,9 @@ public class FileBufferCreation {
 		IPath path1= createLinkedFile("file1", "testResources/ExternalFile");
 		assertNotNull(path1);
 
-		File externalFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/ExternalFile"));
+		File externalFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/ExternalFile"));
 		assertNotNull(externalFile);
-		IPath path2= new Path(externalFile.getAbsolutePath());
+		IPath path2= IPath.fromOSString(externalFile.getAbsolutePath());
 
 		ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
 		manager.connect(path1, LocationKind.NORMALIZE, null);
@@ -543,9 +542,9 @@ public class FileBufferCreation {
 	 */
 	@Test
 	public void test5_location() throws Exception {
-		File externalFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/ExternalFile"));
+		File externalFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/ExternalFile"));
 		assertNotNull(externalFile);
-		IPath path= new Path(externalFile.getAbsolutePath());
+		IPath path= IPath.fromOSString(externalFile.getAbsolutePath());
 
 		ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
 		manager.connect(path, LocationKind.LOCATION, null);

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferFunctions.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferFunctions.java
@@ -38,7 +38,6 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 
@@ -1283,7 +1282,7 @@ public abstract class FileBufferFunctions {
 	 */
 	@Test
 	public void testGetFileStoreAnnotationModel() throws Exception {
-		IFileStore fileStore= EFS.getNullFileSystem().getStore(new Path("/dev/null"));
+		IFileStore fileStore= EFS.getNullFileSystem().getStore(IPath.fromOSString("/dev/null"));
 		assertNotNull(fileStore);
 		fManager.connectFileStore(fileStore, null);
 		try {

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForExternalFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForExternalFiles.java
@@ -23,7 +23,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IProject;
 
@@ -46,10 +45,10 @@ public class FileBuffersForExternalFiles extends FileBufferFunctions {
 
 	@Override
 	protected IPath createPath(IProject project) throws Exception {
-		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/ExternalFile"));
-		File externalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("externalResources/ExternalFile"));
+		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/ExternalFile"));
+		File externalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("externalResources/ExternalFile"));
 		FileTool.copy(sourceFile, externalFile);
-		return new Path(externalFile.getAbsolutePath());
+		return IPath.fromOSString(externalFile.getAbsolutePath());
 	}
 
 	@Override

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForFilesInLinkedFolders.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForFilesInLinkedFolders.java
@@ -28,7 +28,6 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IFile;
@@ -63,12 +62,12 @@ public class FileBuffersForFilesInLinkedFolders extends FileBufferFunctions {
 
 	@Override
 	protected IPath createPath(IProject project) throws Exception {
-		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/linkedFolderTarget/FileInLinkedFolder"));
-		fExternalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("externalResources/linkedFolderTarget/FileInLinkedFolder"));
+		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/linkedFolderTarget/FileInLinkedFolder"));
+		fExternalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("externalResources/linkedFolderTarget/FileInLinkedFolder"));
 		FileTool.copy(sourceFile, fExternalFile);
 
-		IFolder folder= ResourceHelper.createLinkedFolder(project, new Path("LinkedFolder"), fExternalFile.getParentFile());
-		IFile file= folder.getFile(new Path("FileInLinkedFolder"));
+		IFolder folder= ResourceHelper.createLinkedFolder(project, IPath.fromOSString("LinkedFolder"), fExternalFile.getParentFile());
+		IFile file= folder.getFile(IPath.fromOSString("FileInLinkedFolder"));
 		return file.getFullPath();
 	}
 
@@ -99,7 +98,7 @@ public class FileBuffersForFilesInLinkedFolders extends FileBufferFunctions {
 	protected IPath moveUnderlyingFile() throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
 		ResourceHelper.createFolder("project/folderA");
-		IPath path= new Path("/project/folderA/MovedLinkedFile");
+		IPath path= IPath.fromOSString("/project/folderA/MovedLinkedFile");
 		file.move(path, true, false, null);
 
 		file= FileBuffers.getWorkspaceFileAtLocation(path);

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForLinkedFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForLinkedFiles.java
@@ -19,7 +19,6 @@ import org.junit.After;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IFile;
@@ -48,10 +47,10 @@ public class FileBuffersForLinkedFiles extends FileBufferFunctions {
 
 	@Override
 	protected IPath createPath(IProject project) throws Exception {
-		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/LinkedFileTarget"));
-		fExternalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("externalResources/LinkedFileTarget"));
+		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/LinkedFileTarget"));
+		fExternalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("externalResources/LinkedFileTarget"));
 		FileTool.copy(sourceFile, fExternalFile);
-		IFile file= ResourceHelper.createLinkedFile(project, new Path("LinkedFile"), fExternalFile);
+		IFile file= ResourceHelper.createLinkedFile(project, IPath.fromOSString("LinkedFile"), fExternalFile);
 		return file.getFullPath();
 	}
 
@@ -82,7 +81,7 @@ public class FileBuffersForLinkedFiles extends FileBufferFunctions {
 	protected IPath moveUnderlyingFile() throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
 		ResourceHelper.createFolder("project/folderA");
-		IPath path= new Path("/project/folderA/MovedLinkedFile");
+		IPath path= IPath.fromOSString("/project/folderA/MovedLinkedFile");
 		file.move(path, true, false, null);
 
 		file= FileBuffers.getWorkspaceFileAtLocation(path);

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingExternalFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingExternalFiles.java
@@ -21,7 +21,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IProject;
 
@@ -45,7 +44,7 @@ public class FileBuffersForNonExistingExternalFiles extends FileBufferFunctions 
 	protected IPath createPath(IProject project) throws Exception {
 		IPath path= FileBuffersTestPlugin.getDefault().getStateLocation();
 		path= path.append("NonExistingExternalFile");
-		return new Path(path.toFile().getAbsolutePath());
+		return IPath.fromOSString(path.toFile().getAbsolutePath());
 	}
 
 	/*

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForWorkspaceFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForWorkspaceFiles.java
@@ -26,7 +26,6 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IFile;
@@ -78,7 +77,7 @@ public class FileBuffersForWorkspaceFiles extends FileBufferFunctions {
 	protected IPath moveUnderlyingFile() throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
 		ResourceHelper.createFolder("project/folderA/folderB/folderC");
-		IPath path= new Path("/project/folderA/folderB/folderC/MovedWorkspaceFile");
+		IPath path= IPath.fromOSString("/project/folderA/folderB/folderC/MovedWorkspaceFile");
 		file.move(path, true, false, null);
 
 		file= FileBuffers.getWorkspaceFileAtLocation(path);

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForExternalFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForExternalFiles.java
@@ -23,7 +23,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IProject;
 
@@ -46,10 +45,10 @@ public class FileStoreFileBuffersForExternalFiles extends FileStoreFileBufferFun
 
 	@Override
 	protected IPath createPath(IProject project) throws Exception {
-		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("testResources/ExternalFile"));
-		File externalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), new Path("externalResources/ExternalFile"));
+		File sourceFile= FileTool.getFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("testResources/ExternalFile"));
+		File externalFile= FileTool.createTempFileInPlugin(FileBuffersTestPlugin.getDefault(), IPath.fromOSString("externalResources/ExternalFile"));
 		FileTool.copy(sourceFile, externalFile);
-		return new Path(externalFile.getAbsolutePath());
+		return IPath.fromOSString(externalFile.getAbsolutePath());
 	}
 
 	@Override

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForNonExistingExternalFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForNonExistingExternalFiles.java
@@ -21,7 +21,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IProject;
 
@@ -45,7 +44,7 @@ public class FileStoreFileBuffersForNonExistingExternalFiles extends FileStoreFi
 	protected IPath createPath(IProject project) throws Exception {
 		IPath path= FileBuffersTestPlugin.getDefault().getStateLocation();
 		path= path.append("NonExistingExternalFile");
-		return new Path(path.toFile().getAbsolutePath());
+		return IPath.fromOSString(path.toFile().getAbsolutePath());
 	}
 
 	/*

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForWorkspaceFiles.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForWorkspaceFiles.java
@@ -26,7 +26,6 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IFile;
@@ -78,7 +77,7 @@ public class FileStoreFileBuffersForWorkspaceFiles extends FileBufferFunctions {
 	protected IPath moveUnderlyingFile() throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
 		ResourceHelper.createFolder("project/folderA/folderB/folderC");
-		IPath path= new Path("/project/folderA/folderB/folderC/MovedWorkspaceFile");
+		IPath path= IPath.fromOSString("/project/folderA/folderB/folderC/MovedWorkspaceFile");
 		file.move(path, true, false, null);
 
 		file= FileBuffers.getWorkspaceFileAtLocation(path);

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceHelper.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceHelper.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 
@@ -90,7 +89,7 @@ public class ResourceHelper {
 	}
 
 	public static IFolder createFolder(String portableFolderPath) throws CoreException {
-		ContainerCreator creator= new ContainerCreator(ResourcesPlugin.getWorkspace(), new Path(portableFolderPath));
+		ContainerCreator creator= new ContainerCreator(ResourcesPlugin.getWorkspace(), IPath.fromOSString(portableFolderPath));
 		IContainer container= creator.createContainer(NULL_MONITOR);
 		if (container instanceof IFolder)
 			return (IFolder) container;
@@ -115,27 +114,27 @@ public class ResourceHelper {
 
 	public static IFile createLinkedFile(IContainer container, IPath linkPath, File linkedFileTarget) throws CoreException {
 		IFile iFile= container.getFile(linkPath);
-		iFile.createLink(new Path(linkedFileTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		iFile.createLink(IPath.fromOSString(linkedFileTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return iFile;
 	}
 
 	public static IFile createLinkedFile(IContainer container, IPath linkPath, Plugin plugin, IPath linkedFileTargetPath) throws CoreException {
 		File file= FileTool.getFileInPlugin(plugin, linkedFileTargetPath);
 		IFile iFile= container.getFile(linkPath);
-		iFile.createLink(new Path(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		iFile.createLink(IPath.fromOSString(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return iFile;
 	}
 
 	public static IFolder createLinkedFolder(IContainer container, IPath linkPath, File linkedFolderTarget) throws CoreException {
 		IFolder folder= container.getFolder(linkPath);
-		folder.createLink(new Path(linkedFolderTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		folder.createLink(IPath.fromOSString(linkedFolderTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return folder;
 	}
 
 	public static IFolder createLinkedFolder(IContainer container, IPath linkPath, Plugin plugin, IPath linkedFolderTargetPath) throws CoreException {
 		File file= FileTool.getFileInPlugin(plugin, linkedFolderTargetPath);
 		IFolder iFolder= container.getFolder(linkPath);
-		iFolder.createLink(new Path(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		iFolder.createLink(IPath.fromOSString(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return iFolder;
 	}
 
@@ -145,7 +144,7 @@ public class ResourceHelper {
 
 		IProjectDescription desc= workspace.newProjectDescription(projectName);
 		File file= FileTool.getFileInPlugin(plugin, linkPath);
-		IPath projectLocation= new Path(file.getAbsolutePath());
+		IPath projectLocation= IPath.fromOSString(file.getAbsolutePath());
 		if (Platform.getLocation().equals(projectLocation))
 			projectLocation= null;
 		desc.setLocation(projectLocation);

--- a/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceTextFileManagerDocCreationTests.java
+++ b/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceTextFileManagerDocCreationTests.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 
 import org.eclipse.core.internal.filebuffers.ResourceTextFileBufferManager;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -39,9 +39,9 @@ public class ResourceTextFileManagerDocCreationTests extends AbstractFileBufferD
 
 	@Override
 	protected void assertDocumentContent(String expectedContent, String fullPath, LocationKind locKind) {
-		assertEquals(expectedContent, fManager.createEmptyDocument(new Path(fullPath), locKind).get());
+		assertEquals(expectedContent, fManager.createEmptyDocument(IPath.fromOSString(fullPath), locKind).get());
 		if (locKind == LocationKind.IFILE) {
-			IFile file= ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(fullPath));
+			IFile file= ResourcesPlugin.getWorkspace().getRoot().getFile(IPath.fromOSString(fullPath));
 			assertEquals(expectedContent, ((ResourceTextFileBufferManager)fManager).createEmptyDocument(file).get());
 		}
 	}

--- a/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
+++ b/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Export-Package:
  org.eclipse.core.filebuffers.manipulation,
  org.eclipse.core.internal.filebuffers;x-internal:=true
 Require-Bundle: 
- org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)";resolution:=optional,
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)"

--- a/org.eclipse.core.filebuffers/src/org/eclipse/core/filebuffers/manipulation/ContainerCreator.java
+++ b/org.eclipse.core.filebuffers/src/org/eclipse/core/filebuffers/manipulation/ContainerCreator.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 
@@ -130,7 +129,7 @@ public class ContainerCreator {
 	}
 
 	private IFolder createFolderHandle(IContainer container, String folderName) {
-		return container.getFolder(new Path(folderName));
+		return container.getFolder(IPath.fromOSString(folderName));
 	}
 
 	private IProject createProject(IProject projectHandle, IProgressMonitor monitor) throws CoreException {

--- a/org.eclipse.core.filebuffers/src/org/eclipse/core/internal/filebuffers/FileStoreTextFileBuffer.java
+++ b/org.eclipse.core.filebuffers/src/org/eclipse/core/internal/filebuffers/FileStoreTextFileBuffer.java
@@ -31,30 +31,34 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnmappableCharacterException;
 import java.nio.charset.UnsupportedCharsetException;
 
-import org.eclipse.core.filebuffers.IFileBufferStatusCodes;
-import org.eclipse.core.filebuffers.IPersistableAnnotationModel;
-import org.eclipse.core.filebuffers.ITextFileBuffer;
-import org.eclipse.core.filebuffers.LocationKind;
+import org.eclipse.osgi.util.NLS;
+
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
-import org.eclipse.core.resources.IResourceStatus;
+
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.runtime.content.IContentType;
+
+import org.eclipse.core.resources.IResourceStatus;
+
+import org.eclipse.core.filebuffers.IFileBufferStatusCodes;
+import org.eclipse.core.filebuffers.IPersistableAnnotationModel;
+import org.eclipse.core.filebuffers.ITextFileBuffer;
+import org.eclipse.core.filebuffers.LocationKind;
+
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.source.IAnnotationModel;
-import org.eclipse.osgi.util.NLS;
 
 /**
  * @since 3.3 (previously available as JavaTextFileBuffer since 3.3)
@@ -543,8 +547,9 @@ public class FileStoreTextFileBuffer extends FileStoreFileBuffer implements ITex
 	 */
 	private IPath getLocationOrName() {
 		IPath path= getLocation();
-		if (path == null)
-			path= new Path(fFileStore.getName());
+		if (path == null) {
+			path= IPath.fromOSString(fFileStore.getName());
+		}
 		return path;
 	}
 }

--- a/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle:
  org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.search;bundle-version="[3.5.100,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
  org.junit;bundle-version="4.12.0",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.search.tests/src/org/eclipse/search/tests/ResourceHelper.java
+++ b/org.eclipse.search.tests/src/org/eclipse/search/tests/ResourceHelper.java
@@ -24,7 +24,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 
@@ -128,27 +127,27 @@ public class ResourceHelper {
 
 	public static IFile createLinkedFile(IContainer container, IPath linkPath, File linkedFileTarget) throws CoreException {
 		IFile iFile= container.getFile(linkPath);
-		iFile.createLink(new Path(linkedFileTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		iFile.createLink(IPath.fromOSString(linkedFileTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return iFile;
 	}
 
 	public static IFile createLinkedFile(IContainer container, IPath linkPath, Plugin plugin, IPath linkedFileTargetPath) throws CoreException {
 		File file= FileTool.getFileInPlugin(plugin, linkedFileTargetPath);
 		IFile iFile= container.getFile(linkPath);
-		iFile.createLink(new Path(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		iFile.createLink(IPath.fromOSString(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return iFile;
 	}
 
 	public static IFolder createLinkedFolder(IContainer container, IPath linkPath, File linkedFolderTarget) throws CoreException {
 		IFolder folder= container.getFolder(linkPath);
-		folder.createLink(new Path(linkedFolderTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		folder.createLink(IPath.fromOSString(linkedFolderTarget.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return folder;
 	}
 
 	public static IFolder createLinkedFolder(IContainer container, IPath linkPath, Plugin plugin, IPath linkedFolderTargetPath) throws CoreException {
 		File file= FileTool.getFileInPlugin(plugin, linkedFolderTargetPath);
 		IFolder iFolder= container.getFolder(linkPath);
-		iFolder.createLink(new Path(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
+		iFolder.createLink(IPath.fromOSString(file.getAbsolutePath()), IResource.ALLOW_MISSING_LOCAL, NULL_MONITOR);
 		return iFolder;
 	}
 
@@ -158,7 +157,7 @@ public class ResourceHelper {
 
 		IProjectDescription desc= workspace.newProjectDescription(projectName);
 		File file= FileTool.getFileInPlugin(plugin, linkPath);
-		IPath projectLocation= new Path(file.getAbsolutePath());
+		IPath projectLocation= IPath.fromOSString(file.getAbsolutePath());
 		if (Platform.getLocation().equals(projectLocation))
 			projectLocation= null;
 		desc.setLocation(projectLocation);
@@ -172,7 +171,7 @@ public class ResourceHelper {
 
 	public static IProject createJUnitSourceProject(String projectName) throws CoreException, ZipException, IOException {
 		IProject project= ResourceHelper.createProject(projectName);
-		ZipFile zip= new ZipFile(FileTool.getFileInPlugin(SearchTestPlugin.getDefault(), new Path("testresources/junit37-noUI-src.zip"))); //$NON-NLS-1$
+		ZipFile zip= new ZipFile(FileTool.getFileInPlugin(SearchTestPlugin.getDefault(), IPath.fromOSString("testresources/junit37-noUI-src.zip"))); //$NON-NLS-1$
 		FileTool.unzip(zip, project.getLocation().toFile());
 		project.refreshLocal(IResource.DEPTH_INFINITE, null);
 		return project;

--- a/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/org.eclipse.search/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Export-Package: org.eclipse.search.core.text,
  org.eclipse.search2.internal.ui.text;x-internal:=true,
  org.eclipse.search2.internal.ui.text2;x-internal:=true
 Require-Bundle: 
- org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.14.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPageDescriptor.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPageDescriptor.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IFile;
@@ -144,7 +144,7 @@ class SearchPageDescriptor implements IPluginContribution, Comparable<SearchPage
 		if (imageName == null)
 			return null;
 		Bundle bundle = Platform.getBundle(getPluginId());
-		return SearchPluginImages.createImageDescriptor(bundle, new Path(imageName), true);
+		return SearchPluginImages.createImageDescriptor(bundle, IPath.fromOSString(imageName), true);
 	}
 
 	/**

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPluginImages.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPluginImages.java
@@ -21,7 +21,6 @@ import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -36,7 +35,7 @@ public class SearchPluginImages {
 	// The plugin registry
 	private final static ImageRegistry PLUGIN_REGISTRY= SearchPlugin.getDefault().getImageRegistry();
 
-	private static final IPath ICONS_PATH= new Path("$nl$/icons/full"); //$NON-NLS-1$
+	private static final IPath ICONS_PATH = IPath.fromOSString("$nl$/icons/full"); //$NON-NLS-1$
 
 	public static final String T_OBJ= "obj16/"; //$NON-NLS-1$
 	public static final String T_WIZBAN= "wizban/"; //$NON-NLS-1$

--- a/org.eclipse.search/search/org/eclipse/search/internal/ui/SorterDescriptor.java
+++ b/org.eclipse.search/search/org/eclipse/search/internal/ui/SorterDescriptor.java
@@ -17,7 +17,7 @@ import org.osgi.framework.Bundle;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -84,7 +84,7 @@ class SorterDescriptor {
 		if (imageName == null)
 			return null;
 		Bundle bundle = Platform.getBundle(fElement.getContributor().getName());
-		return SearchPluginImages.createImageDescriptor(bundle, new Path(imageName), true);
+		return SearchPluginImages.createImageDescriptor(bundle, IPath.fromOSString(imageName), true);
 	}
 
 	/**

--- a/org.eclipse.text.quicksearch.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.text.quicksearch.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch.tests
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.text.quicksearch;bundle-version="1.0.300",
  org.eclipse.core.resources,

--- a/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/MockResource.java
+++ b/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/MockResource.java
@@ -30,7 +30,6 @@ import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
@@ -39,7 +38,7 @@ public class MockResource implements IResource {
 	IPath fullPath;
 
 	public MockResource(String pathStr) {
-		this.fullPath = new Path(pathStr);
+		this.fullPath = IPath.fromOSString(pathStr);
 	}
 
 	@Override

--- a/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/PrioriTreeTest.java
+++ b/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/PrioriTreeTest.java
@@ -14,7 +14,7 @@ import static org.eclipse.text.quicksearch.internal.core.priority.PriorityFuncti
 import static org.eclipse.text.quicksearch.internal.core.priority.PriorityFunction.PRIORITY_IGNORE;
 import static org.junit.Assert.assertEquals;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.text.quicksearch.internal.core.priority.PrioriTree;
 import org.junit.Before;
 import org.junit.Test;
@@ -157,7 +157,7 @@ public class PrioriTreeTest {
 	}
 
 	private void setPriority(String pathStr, double pri) {
-		tree.setPriority(new Path(pathStr), pri);
+		tree.setPriority(IPath.fromOSString(pathStr), pri);
 	}
 
 	private void checkPriority(double expected, String pathStr) {

--- a/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/ResourceMatcherTest.java
+++ b/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/ResourceMatcherTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.text.quicksearch.internal.core.pathmatch.ResourceMatcher;
 import org.eclipse.text.quicksearch.internal.core.pathmatch.ResourceMatchers;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class ResourceMatcherTest {
 	}
 
 	private void assertMatch(boolean expectedMatch, String patterns, String path) {
-		assertTrue(new Path(path).isAbsolute());
+		assertTrue(IPath.fromOSString(path).isAbsolute());
 		ResourceMatcher matcher = ResourceMatchers.commaSeparatedPaths(patterns);
 		assertEquals("Wrong match with pattern: '" + patterns + "'", expectedMatch, matcher.matches(new MockResource(path)));
 

--- a/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.editors.tests
 Require-Bundle: 
- org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.junit;bundle-version="4.12.0",
  org.eclipse.jface;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/DocumentProviderRegistryTest.java
+++ b/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/DocumentProviderRegistryTest.java
@@ -23,7 +23,7 @@ import org.junit.rules.TemporaryFolder;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -68,7 +68,7 @@ public class DocumentProviderRegistryTest {
 	@Test
 	public void testFindByExtensionNonWorkspace() throws Exception {
 		File external = tmp.newFile("external.testfile");
-		IFileStore store = EFS.getLocalFileSystem().getStore(new Path(external.getCanonicalPath()));
+		IFileStore store = EFS.getLocalFileSystem().getStore(IPath.fromOSString(external.getCanonicalPath()));
 		IEditorInput editorInput = new FileStoreEditorInput(store);
 		IDocumentProvider provider = DocumentProviderRegistry.getDefault().getDocumentProvider(editorInput);
 		assertEquals("Unexpected document provider found : " + provider.getClass().getName(),

--- a/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Export-Package:
  org.eclipse.ui.internal.texteditor;x-internal:=true,
  org.eclipse.ui.texteditor
 Require-Bundle: 
- org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.swt;bundle-version="[3.101.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/templates/ContributionTemplateStore.java
+++ b/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/templates/ContributionTemplateStore.java
@@ -27,7 +27,7 @@ import org.osgi.framework.Bundle;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.text.templates.TemplatePersistenceData;
@@ -130,12 +130,12 @@ public class ContributionTemplateStore extends TemplateStore {
 		String file= element.getAttribute(FILE);
 		if (file != null) {
 			Bundle plugin = Platform.getBundle(element.getContributor().getName());
-			URL url= FileLocator.find(plugin, Path.fromOSString(file), null);
+			URL url= FileLocator.find(plugin, IPath.fromOSString(file), null);
 			if (url != null) {
 				ResourceBundle bundle= null;
 				String translations= element.getAttribute(TRANSLATIONS);
 				if (translations != null) {
-					URL bundleURL= FileLocator.find(plugin, Path.fromOSString(translations), null);
+					URL bundleURL= FileLocator.find(plugin, IPath.fromOSString(translations), null);
 					if (bundleURL != null) {
 						try (InputStream bundleStream= bundleURL.openStream()) {
 							bundle= new PropertyResourceBundle(bundleStream);

--- a/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/NonExistingFileEditorInput.java
+++ b/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/NonExistingFileEditorInput.java
@@ -18,7 +18,6 @@ import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -84,7 +83,7 @@ public class NonExistingFileEditorInput implements IEditorInput, ILocationProvid
 	public IPath getPath(Object element) {
 		if (element instanceof NonExistingFileEditorInput) {
 			NonExistingFileEditorInput input= (NonExistingFileEditorInput)element;
-			return new Path(input.fFileStore.toURI().getPath());
+			return IPath.fromOSString(input.fFileStore.toURI().getPath());
 		}
 		return null;
 	}

--- a/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/MarkerAnnotationPreferences.java
+++ b/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/MarkerAnnotationPreferences.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IMarker;
@@ -532,7 +532,7 @@ public class MarkerAnnotationPreferences {
 		if (bundle == null)
 			return null;
 
-		URL url= FileLocator.find(bundle, new Path(iconPath), null);
+		URL url= FileLocator.find(bundle, IPath.fromOSString(iconPath), null);
 		if (url != null)
 			return ImageDescriptor.createFromURL(url);
 

--- a/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.17.0.qualifier
+Bundle-Version: 3.17.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
@@ -24,7 +24,7 @@ Export-Package:
  org.eclipse.ui.texteditor.spelling,
  org.eclipse.ui.texteditor.templates
 Require-Bundle: 
- org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.compare.core;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.100,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.19.0,4.0.0)",

--- a/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/rulers/ExtensionPointHelper.java
+++ b/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/rulers/ExtensionPointHelper.java
@@ -23,9 +23,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 
@@ -121,7 +121,7 @@ public final class ExtensionPointHelper {
 		if (bundle == null)
 			return dflt;
 
-		Path path= new Path(value);
+		IPath path = IPath.fromOSString(value);
 		return FileLocator.find(bundle, path, null);
 	}
 

--- a/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesPageImages.java
+++ b/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesPageImages.java
@@ -20,7 +20,7 @@ import org.osgi.framework.Bundle;
 import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -113,7 +113,7 @@ class TemplatesPageImages {
 		Bundle bundle= Platform.getBundle(TextEditorPlugin.PLUGIN_ID);
 		URL url= null;
 		if (bundle != null) {
-			url= FileLocator.find(bundle, new Path(path), null);
+			url = FileLocator.find(bundle, IPath.fromOSString(path), null);
 			desc= ImageDescriptor.createFromURL(url);
 		}
 		fgImageRegistry.put(key, desc);


### PR DESCRIPTION
Use the new `IPath` factory methods introduced in https://github.com/eclipse-equinox/equinox/pull/228 in Platform-Text.

With this PR `org.eclipse.core.runtime.Path` is not referenced anymore in Platform-Text's entire code base.