### PR TITLE
Propagate exception on storage document content stream closure

### DIFF
--- a/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/StorageDocumentProvider.java
+++ b/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/StorageDocumentProvider.java
@@ -134,20 +134,13 @@ public class StorageDocumentProvider extends AbstractDocumentProvider implements
 		if (encoding == null) {
 			encoding= getDefaultEncoding();
 		}
-		try {
+		try (contentStream) { // close content stream after read (PDE relies on it)
 			String content= new String(contentStream.readAllBytes(), encoding);
 			document.set(content);
 		} catch (IOException x) {
 			String message= (x.getMessage() != null ? x.getMessage() : ""); //$NON-NLS-1$
 			IStatus s= new Status(IStatus.ERROR, PlatformUI.PLUGIN_ID, IStatus.OK, message, x);
 			throw new CoreException(s);
-		} finally {
-			try {
-				// undocumented implementation detail kept for historic reasons (for example PDE relies on it):
-				contentStream.close();
-			} catch (IOException x) {
-				// ignore
-			}
 		}
 	}
 


### PR DESCRIPTION
In some cases (eg piped content), `InputStream` closure may be the first opportunity for the document content provider to indicate failure. We should not ignore exceptions when closing the content stream. This change ensures that an `IOException` thrown when closing the stream is propagated to the caller in the same manner as when reading the stream.